### PR TITLE
Better default config

### DIFF
--- a/app/templates/basic/config.js
+++ b/app/templates/basic/config.js
@@ -16,4 +16,4 @@ var config = {
   }
 };
 
-module.exports = config[process.env.NODE_ENV || 'development'];
+module.exports = config[process.env.NODE_ENV] || config.development;

--- a/app/templates/express4/basic/config.js
+++ b/app/templates/express4/basic/config.js
@@ -16,4 +16,4 @@ var config = {
   }
 };
 
-module.exports = config[process.env.NODE_ENV || 'development'];
+module.exports = config[process.env.NODE_ENV] || config.development;

--- a/app/templates/express4/mvc/config.js
+++ b/app/templates/express4/mvc/config.js
@@ -25,4 +25,4 @@ var config = {
   }
 };
 
-module.exports = config[process.env.NODE_ENV || 'development'];
+module.exports = config[process.env.NODE_ENV] || config.development;

--- a/app/templates/mvc/config.js
+++ b/app/templates/mvc/config.js
@@ -25,4 +25,4 @@ var config = {
   }
 };
 
-module.exports = config[process.env.NODE_ENV || 'development'];
+module.exports = config[process.env.NODE_ENV] || config.development;


### PR DESCRIPTION
Prevents the config to be undefined if NODE_ENV contains an unexpected value.

For example, if NODE_ENV was 'asdfghjkl', the config would be undefined. This way we default it to the 'development' config.