### PR TITLE
Fixed issue with app/templates/gruntfiles/Gruntfile.js concat and uglify tasks.

### DIFF
--- a/app/templates/gruntfiles/Gruntfile.js
+++ b/app/templates/gruntfiles/Gruntfile.js
@@ -13,10 +13,8 @@ module.exports = function (grunt) {
       css: {
         // add your css files over here to concatenate all css files
         // let's save our site users some bandwith
-        files: {
-          src: ['public/vendor/bootstrap/dist/css/bootstrap.min.css', 'public/css/styles.min.css'],
-          dest: 'public/css/app.styles.min.css'
-        }
+        src: ['public/vendor/bootstrap/dist/css/bootstrap.min.css', 'public/css/styles.min.css'],
+        dest: 'public/css/app.styles.min.css'
       }
     },
     uglify: {
@@ -26,8 +24,10 @@ module.exports = function (grunt) {
         }
       },
       target: {
-        // add your js files over here to minify them into one javascript source file
-        'public/js/app.min.js': ['public/vendor/jquery/dist/jquery.min.js', 'public/vendor/bootstrap/dist/js/bootstrap.min.js', 'public/js/main.js']
+        files: {
+          // add your js files over here to minify them into one javascript source file
+          'public/js/app.min.js': ['public/vendor/jquery/dist/jquery.min.js', 'public/vendor/bootstrap/dist/js/bootstrap.min.js', 'public/js/main.js']
+        }
       }
     },
     <%= cssPreprocessor %>: {


### PR DESCRIPTION

concat was incorrectly writing a 'dest' and 'src' file into the root
instead of creating the 'public/css/app.styles.min.css' as expected.

uglify was missing the 'file' key inside 'target' which resulted in
the 'public/js/app.min.js' never being written.